### PR TITLE
Fix file max size upload

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 
-# Laravel File Explorer -
+# Laravel File Explorer
 
 ![Laravel File Explorer image](docs/laravel-file-explorer-merged-demo.png)
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 
-# Laravel File Explorer
+# Laravel File Explorer -
 
 ![Laravel File Explorer image](docs/laravel-file-explorer-merged-demo.png)
 

--- a/src/Requests/UploadItemsRequest.php
+++ b/src/Requests/UploadItemsRequest.php
@@ -6,7 +6,6 @@ use AlirezaMoh\LaravelFileExplorer\Services\ConfigRepository;
 use Illuminate\Contracts\Validation\Validator;
 use Illuminate\Http\Exceptions\HttpResponseException;
 use Illuminate\Support\Str;
-use Illuminate\Validation\Rules\File;
 
 class UploadItemsRequest extends BaseRequest
 {
@@ -73,11 +72,11 @@ class UploadItemsRequest extends BaseRequest
         ];
 
         if ($allowedFileExtensions !== null) {
-            $rules['items.*'][] = File::types($allowedFileExtensions);
+            $rules['items.*'][] = "mimes:" . implode(',', $allowedFileExtensions);
         }
 
         if ($maxFileSize !== null) {
-            $rules['items.*'][] = File::default()->max($maxFileSize);
+            $rules['items.*'][] = "max:$maxFileSize";
         }
 
         return $rules;

--- a/src/Requests/UploadItemsRequest.php
+++ b/src/Requests/UploadItemsRequest.php
@@ -77,7 +77,7 @@ class UploadItemsRequest extends BaseRequest
         }
 
         if ($maxFileSize !== null) {
-            $rules['items.*'][] = File::max($maxFileSize);
+            $rules['items.*'][] = File::default()->max($maxFileSize);
         }
 
         return $rules;


### PR DESCRIPTION
Hello!

When uploading a file indicating in the config a specific size I have seen that the File Class of the rules, the max function is not static so it cannot be called in the way it is.

`exception
: 
"Error"
file
: 
"/var/www/html/packages/furrutia-c/laravel-file-explorer/src/Requests/UploadItemsRequest.php"
line
: 
80
message
: 
"Non-static method Illuminate\\Validation\\Rules\\File::max() cannot be called statically"`